### PR TITLE
Fix zlib URL to fix compiling

### DIFF
--- a/Dockerfile-linux
+++ b/Dockerfile-linux
@@ -25,7 +25,12 @@ RUN \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \ 
-  curl --proto '=https' --tlsv1.3 -fsSL "https://zlib.net/zlib-${zlib_version}.tar.gz" -o "zlib-$zlib_version.tar.gz" && \
+  curl --proto '=https' --tlsv1.3 -fsSL -o "zlib-$zlib_version.tar.gz" $( \
+    curl --proto '=https' --tlsv1.3 -fsLIw '%{response_code} %{url}' -o /dev/null "https://zlib.net/zlib-${zlib_version}.tar.gz" | \
+      awk '$1 == 200 { print $2 } $1 != 200 { exit 1 }' || \
+    curl --proto '=https' --tlsv1.3 -fsSLIw '%{response_code} %{url}' -o /dev/null "https://zlib.net/fossils/zlib-${zlib_version}.tar.gz" | \
+      awk '$1 == 200 { print $2 } $1 != 200' \
+  ) && \
   echo "$zlib_hash  zlib-$zlib_version.tar.gz" | shasum -a 256 -c - && \
   tar -zxvf "zlib-$zlib_version.tar.gz" && \
   cd "zlib-$zlib_version" && \

--- a/Dockerfile-mingw
+++ b/Dockerfile-mingw
@@ -30,7 +30,12 @@ ENV PATH="/usr/i686-w64-mingw32/bin:$PATH"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN \
-  curl --proto '=https' --tlsv1.3 -fsSL "https://zlib.net/zlib-${zlib_version}.tar.gz" -o "zlib-$zlib_version.tar.gz" && \
+  curl --proto '=https' --tlsv1.3 -fsSL -o "zlib-$zlib_version.tar.gz" $( \
+    curl --proto '=https' --tlsv1.3 -fsLIw '%{response_code} %{url}' -o /dev/null "https://zlib.net/zlib-${zlib_version}.tar.gz" | \
+      awk '$1 == 200 { print $2 } $1 != 200 { exit 1 }' || \
+    curl --proto '=https' --tlsv1.3 -fsSLIw '%{response_code} %{url}' -o /dev/null "https://zlib.net/fossils/zlib-${zlib_version}.tar.gz" | \
+      awk '$1 == 200 { print $2 } $1 != 200' \
+  ) && \
   echo "$zlib_hash  zlib-$zlib_version.tar.gz" | shasum -a 256 -c - && \
   tar -zxvf "zlib-$zlib_version.tar.gz" && \
   cd "zlib-$zlib_version" && \

--- a/build_darwin.sh
+++ b/build_darwin.sh
@@ -2,7 +2,12 @@
 set -eu
 
 # Download and verify dependencies
-curl --proto '=https' --tlsv1.2 -fsSL "https://zlib.net/zlib-$ZLIB_VERSION.tar.gz" -o "zlib-$ZLIB_VERSION.tar.gz"
+curl --proto '=https' --tlsv1.2 -fsSL -o "zlib-$ZLIB_VERSION.tar.gz" $(
+    curl --proto '=https' --tlsv1.2 -fsLIw '%{response_code} %{url}' -o /dev/null "https://zlib.net/zlib-$ZLIB_VERSION.tar.gz" |
+        awk '$1 == 200 { print $2 } $1 != 200 { exit 1 }' ||
+    curl --proto '=https' --tlsv1.2 -fsSLIw '%{response_code} %{url}' -o /dev/null "https://zlib.net/fossils/zlib-$ZLIB_VERSION.tar.gz" |
+        awk '$1 == 200 { print $2 } $1 != 200'
+)
 echo "$ZLIB_HASH  zlib-$ZLIB_VERSION.tar.gz" | shasum -a 256 -c -
 
 curl --proto '=https' --tlsv1.2 -fsSL "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" -o "openssl-$OPENSSL_VERSION.tar.gz"


### PR DESCRIPTION
All but the newest versions are now in the fossils subfolder on zlib.net, hopefully 0.4.8.9 will compile now.

I added a fallback that doesn't add variables or if checks (not counting the ones in awk).