### PR TITLE
release: add version v0.4.9.5

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -6,7 +6,7 @@ export MACOSX_DEPLOYMENT_TARGET=10.15
 # Reset version number to zero everytime TOR_VERSION changes.
 export BRAVE_TOR_VERSION="0"
 
-export TOR_VERSION="0.4.8.22"
+export TOR_VERSION="0.4.9.5"
 
 export ZLIB_VERSION="1.3.1"
 export LIBEVENT_VERSION="2.1.12-stable"
@@ -15,6 +15,6 @@ export OPENSSL_VERSION="3.6.1"
 export ZLIB_HASH="9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
 export LIBEVENT_HASH=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
 export OPENSSL_HASH="b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e"
-export TOR_HASH="c88620d9278a279e3d227ff60975b84aa41359211f8ecff686019923b9929332"
+export TOR_HASH="c949c2f86b348e64891976f6b1e49c177655b23df97193049bf1b8cd3099e179"
 
 export DOCKER="$(command -v docker || command -v podman)"


### PR DESCRIPTION
This updates from 0.4.8-rc22 to 0.4.9.5.
- [Changelog](https://gitweb.torproject.org/tor.git/plain/ChangeLog?h=tor-0.4.9.5)
- [Tag](https://gitweb.torproject.org/tor.git/tag/?h=tor-0.4.9.5)